### PR TITLE
Fix datetime formatting in confrimation email

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -4,6 +4,7 @@ class ConfirmationMailer < ApplicationMailer
     @user = User.find(data[:user_id])
     @connection = User.find(data[:connection_id])
     @data = data
+    @data[:datetime] = Time.parse(data[:meeting_date]).strftime("%m/%d/%Y %I:%M %p")
     mail(to: [@user.email, @connection.email], subject: "You have a confirmed meeting through TechConnect")
   end
 

--- a/app/views/confirmation_mailer/confirm.html.erb
+++ b/app/views/confirmation_mailer/confirm.html.erb
@@ -4,7 +4,7 @@
 Meeting Details:
 <ul>
   <li>Meeting Location: <%= @data[:meeting_location] %></li>
-  <li>Meeting Time: <%= @data[:meeting_date] %></li>
+  <li>Meeting Time: <%= @data[:datetime] %></li>
 </ul>
 
 Contact Details:

--- a/app/views/confirmation_mailer/confirm.text.erb
+++ b/app/views/confirmation_mailer/confirm.text.erb
@@ -4,7 +4,7 @@
 Meeting Details:
 <ul>
   <li>Meeting Location: <%= @data[:meeting_location] %></li>
-  <li>Meeting Time: <%= @data[:meeting_date] %></li>
+  <li>Meeting Time: <%= @data[:datetime] %></li>
 </ul>
 
 Contact Details:


### PR DESCRIPTION
- [ ] Wrote Tests
- [ ] Implemented
- [ ] Reviewed


# Necessary checkmarks:
- [X] All Tests are Passing
- [X] The code will run locally

## Type of change
- [ ] New feature
- [X] Bug Fix

# Implements/Fixes:
## Description of Changes
Confirmation email formatting was not showing the time of the confirmed meeting.  Fixed this in the confirmation_mailer.rb file 

closes #

# Check the correct boxes
- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [X] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [X] My code has no unused/commented out code
- [X] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:
![](https://media2.giphy.com/media/YmjleYhDTUiYw/giphy.webp?cid=3640f6095c86da34706147552e221df7)