### PR TITLE
Email security

### DIFF
--- a/app/mailers/connection_request_mailer.rb
+++ b/app/mailers/connection_request_mailer.rb
@@ -1,13 +1,20 @@
+require 'securerandom'
+
 class ConnectionRequestMailer < ApplicationMailer
 
   def connect(data)
     @connection = User.find(data[:connection_id])
     @user = User.find_by(api_key: data[:api_key])
+    @token = random_generator
     @data = data
     @data[:datetime_1] = Time.parse(data[:datetime_1]).strftime("%m/%d/%Y %I:%M %p")
     @data[:datetime_2] = Time.parse(data[:datetime_2]).strftime("%m/%d/%Y %I:%M %p")
     @data[:datetime_3] = Time.parse(data[:datetime_3]).strftime("%m/%d/%Y %I:%M %p")
 
     mail(to: @connection.email, subject: "#{@user.name} is requesting a connection")
+  end
+
+  def random_generator
+    SecureRandom.base64(12)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -20,4 +20,8 @@ class Message < ApplicationRecord
     Message.where("user_id = #{user.id} OR connection_id = #{user.id}")
   end
 
+  def self.find_token?(token)
+    Message.where(token: token)
+  end 
+
 end

--- a/app/views/connection_request_mailer/connect.html.erb
+++ b/app/views/connection_request_mailer/connect.html.erb
@@ -25,6 +25,10 @@
     <label for="radio3"><%= @data[:datetime_3] %></label><br>
   </div>
 
+  <div id="token">
+    <input type="hidden" name="token" value="<%= @token %>">
+  </div>
+
   <div>
     <br><button type="submit" name= "<%=@connection.email %>-confirmed" >Make Meeting</button><br>
 

--- a/app/views/connection_request_mailer/connect.text.erb
+++ b/app/views/connection_request_mailer/connect.text.erb
@@ -25,6 +25,10 @@
     <label for="radio3"><%= @data[:datetime_3] %></label><br>
   </div>
 
+  <div id="token">
+    <input type="hidden" name="token" value="<%= @token %>">
+  </div>
+
   <div>
     <br><button type="submit" name= "<%=@connection.email %>-confirmed" >Make Meeting</button><br>
 

--- a/db/migrate/20190213181758_create_messages.rb
+++ b/db/migrate/20190213181758_create_messages.rb
@@ -4,6 +4,7 @@ class CreateMessages < ActiveRecord::Migration[5.2]
       t.string :status
       t.datetime :meeting_date
       t.string :meeting_location
+      t.string :token
       t.references :user, foreign_key: true
       t.integer :connection_id
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_02_13_181758) do
     t.string "status"
     t.datetime "meeting_date"
     t.string "meeting_location"
+    t.string "token"
     t.bigint "user_id"
     t.integer "connection_id"
     t.datetime "created_at", null: false

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     status   { |n| "Status #{n}" }
     meeting_date { |n| DateTime.new(2001,2,3,4,5,6) }
     meeting_location { |n| "Meeting Location #{n}" }
-
+    token { "abc123" }
     user
     connection {|n| user }
   end

--- a/spec/requests/api/v1/mailer_request_spec.rb
+++ b/spec/requests/api/v1/mailer_request_spec.rb
@@ -21,6 +21,7 @@ describe "Mailers Request" do
     expect(response).to be_successful
 
     parsed = JSON.parse(response.body, symbolize_names: true)
+
     expect(parsed[:success]).to eq("Email Sent")
   end
 

--- a/spec/requests/api/v1/message_request_spec.rb
+++ b/spec/requests/api/v1/message_request_spec.rb
@@ -57,4 +57,15 @@ describe 'making a message api and response' do
     expect(Message.where(user_id: user_1.id).length).to eq(1)
     expect(Message.where(user_id: user_1.id).last.status).to eq("declined")
   end
+  it 'GET users/:id/messages/new' do
+    user_1 = create(:user, email: "sending@gmail.com")
+    user_2 = create(:user, email: "test@gmail.com")
+    message = create(:message, user: user_1, connection: user_2)
+    params = {"meeting_location"=>"Starbucks on Broadway", "meeting_date"=>"02-07-2019 06:17", "#{user_2.email}-confirmed" => "", "token" => "abc123"}
+    expect(Message.where(user_id: user_1.id).length).to eq(1)
+
+    get "/api/v1/users/#{user_1.id}/messages/new", params: params
+
+    expect(Message.where(user_id: user_1.id).length).to eq(1)
+  end
 end

--- a/spec/requests/api/v1/user_request_spec.rb
+++ b/spec/requests/api/v1/user_request_spec.rb
@@ -95,7 +95,6 @@ describe 'making a position api and response' do
 
     expect(response).to be_successful
     parsed = JSON.parse(response.body, symbolize_names: true)
-
     expect(parsed[:data]).to be_a(Array)
     expect(parsed[:data].length).to eq(2)
     expect(parsed[:data][0][:attributes]).to have_key(:name)


### PR DESCRIPTION
- [X] Wrote Tests
- [X] Implemented
- [X] Reviewed


# Necessary checkmarks:
- [X] All Tests are Passing
- [X] The code will run locally

## Type of change
- [ ] New feature
- [X] Bug Fix

# Implements/Fixes:
## Description of Changes
Added a token attribute to the message table.  The token is a randomly generated alpha-numeric string.  When a user gets a meeting email, there is a hidden field that holds a randomly generated token.  When the user selects Confirm to confirm a meeting, then the token is sent back to the app.  If the app cannot find a message with that token already in use, it will create a new message and send an email.  Otherwise, no message is sent and no email is sent.

Outstanding issue:  Since we don't save declined meeting messages, there is no way to stop a user from clicking on the Decline button over and over again which will send out a decline email to the other user over and over again.  Any thoughts on fixing that issue?

closes #

# Check the correct boxes
- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [ ] No Tests have been changed
- [X] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [X] My code has no unused/commented out code
- [X] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:

![](https://media1.giphy.com/media/bTzFnjHPuVvva/200.webp?cid=3640f6095c8fd5797145517a59444c1f)